### PR TITLE
Trim cover text validation

### DIFF
--- a/stegcloak.js
+++ b/stegcloak.js
@@ -50,7 +50,9 @@ class StegCloak {
   }
 
   hide(message, password, cover = "This is a confidential text") {
-    if (cover.split(" ").length === 1) {
+    cover = cover.trim();
+    const tokens = cover.split(/\s+/).filter(Boolean);
+    if (tokens.length < 2) {
       throw new Error("Minimum two words required");
     }
 


### PR DESCRIPTION
## Summary
- Trim cover text and validate word count before embedding secret

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68a7e2f5313883259ff0dcbb2564472c