### PR TITLE
Validate hidden flags before decoding messages

### DIFF
--- a/components/message.js
+++ b/components/message.js
@@ -39,6 +39,11 @@ const zwcOperations = (zwc) => {
 
   const flagDetector = (x) => {
     const i = zwc.indexOf(x[0]);
+    if (i < 0 || i > 2) {
+      throw new Error(
+        "Invalid flag detected. Ensure the message was created using StegCloak."
+      );
+    }
     if (i === 0) {
       return {
         encrypt: true,
@@ -49,12 +54,11 @@ const zwcOperations = (zwc) => {
         encrypt: true,
         integrity: false,
       };
-    } else if (i === 2) {
-      return {
-        encrypt: false,
-        integrity: false,
-      };
     }
+    return {
+      encrypt: false,
+      integrity: false,
+    };
   };
 
   // Message curried functions
@@ -67,7 +71,12 @@ const zwcOperations = (zwc) => {
 
   // ZWC string to data
   const concealToData = (str) => {
-    const { encrypt, integrity } = flagDetector(str);
+    let encrypt, integrity;
+    try {
+      ({ encrypt, integrity } = flagDetector(str));
+    } catch (err) {
+      throw new Error(`Invalid hidden flag: ${err.message}`);
+    }
     return {
       encrypt,
       integrity,

--- a/stegcloak.js
+++ b/stegcloak.js
@@ -82,15 +82,20 @@ class StegCloak {
   reveal(secret, password) {
     // Detach invisible characters and convert back to visible characters and also returns analysis of if encryption or integrity check was done
 
-    const {
-      data,
-      integrity,
-      encrypt
-    } = R.pipe(
-      detach,
-      expand,
-      concealToData
-    )(secret);
+    let data, integrity, encrypt;
+    try {
+      ({
+        data,
+        integrity,
+        encrypt
+      } = R.pipe(
+        detach,
+        expand,
+        concealToData
+      )(secret));
+    } catch (err) {
+      throw new Error(`Failed to reveal message: ${err.message}`);
+    }
 
     const decryptStream = encrypt ?
       decrypt({


### PR DESCRIPTION
## Summary
- validate zero-width flag and throw when out of range
- handle flag parsing errors in concealToData and reveal

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx standard components/message.js stegcloak.js` *(fails: Extra semicolon and formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68a7ed3b55648325b6a863e18e9f67cf