### PR TITLE
Fix detach handling for multiple hidden segments

### DIFF
--- a/components/message.js
+++ b/components/message.js
@@ -92,21 +92,17 @@ const zwcOperations = (zwc) => {
 
   const detach = (str) => {
     const eachWords = str.split(" ");
-    const detached = eachWords.reduce((acc, word) => {
+    for (const word of eachWords) {
       const zwcBound = word.split("");
       const intersected = intersection(zwc, zwcBound);
       if (intersected.length !== 0) {
-        const limit = zwcBound.findIndex((x, i) => !~zwc.indexOf(x));
+        const limit = zwcBound.findIndex((x) => !~zwc.indexOf(x));
         return word.slice(0, limit);
       }
-      return acc;
-    }, '');
-    if (!detached) {
-      throw new Error(
-        "Invisible stream not detected! Please copy and paste the StegCloak text sent by the sender."
-      );
     }
-    return detached;
+    throw new Error(
+      "Invisible stream not detected! Please copy and paste the StegCloak text sent by the sender."
+    );
   };
 
   return {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/detach.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/detach.test.js
+++ b/test/detach.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const StegCloak = require('../stegcloak.js');
+const { zwcOperations } = require('../components/message.js');
+
+const zwc = StegCloak.zwc;
+const { detach } = zwcOperations(zwc);
+
+// Ensure detach returns the first hidden segment when multiple are present
+const first = zwc[0] + zwc[1];
+const second = zwc[2] + zwc[3];
+const cover = `hello ${first}world ${second}again`;
+
+assert.strictEqual(detach(cover), first, 'detach should return the first hidden segment');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- stop `detach` after the first zero-width sequence is found
- add test covering multiple hidden segments
- wire tests into npm `test` script

## Testing
- `npm test`
- `npx standard components/message.js test/detach.test.js` *(fails: strings must use singlequote, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a7fdba76888325a268f34ba55db345