### PR TITLE
Handle whitespace in detach

### DIFF
--- a/components/message.js
+++ b/components/message.js
@@ -91,7 +91,7 @@ const zwcOperations = (zwc) => {
   };
 
   const detach = (str) => {
-    const eachWords = str.split(" ");
+    const eachWords = str.split(/\s+/).filter(Boolean);
     for (const word of eachWords) {
       const zwcBound = word.split("");
       const intersected = intersection(zwc, zwcBound);

--- a/test/detach.test.js
+++ b/test/detach.test.js
@@ -8,8 +8,23 @@ const { detach } = zwcOperations(zwc);
 // Ensure detach returns the first hidden segment when multiple are present
 const first = zwc[0] + zwc[1];
 const second = zwc[2] + zwc[3];
-const cover = `hello ${first}world ${second}again`;
 
-assert.strictEqual(detach(cover), first, 'detach should return the first hidden segment');
+const covers = [
+  `hello ${first}world ${second}again`,
+  `hello\t${first}world\t${second}again`,
+  `hello\n${first}world\n${second}again`,
+  `hello \t\n${first}world  \n\t${second}again`,
+];
+
+covers.forEach((cover, idx) => {
+  assert.strictEqual(
+    detach(cover),
+    first,
+    `detach should return the first hidden segment for case ${idx + 1}`
+  );
+});
 
 console.log('All tests passed.');
+
+process.exit(0);
+

--- a/test/expand.test.js
+++ b/test/expand.test.js
@@ -11,3 +11,5 @@ assert.strictEqual(expand(zwc[0]), '', 'expand should return empty string when d
 assert.throws(() => expand('x' + zwc[4]), /Unknown compression flag/, 'expand should throw when flag is invalid');
 
 console.log('All tests passed.');
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- Split message segments using regular expression to support tabs, newlines and repeated spaces
- Test detachment across varied whitespace and ensure first hidden segment is returned
- Ensure tests exit cleanly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a80e1a87e48325b238ba0a04483c28