### PR TITLE
fix: use input type for CLI prompts

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -52,7 +52,7 @@ function cliHide(secret, password, cover, crypt, integrity, op) {
 };
 
 function createStringQuestion(str, nameIt) {
-  return { type: 'string', message: str, name: nameIt }
+  return { type: 'input', message: str, name: nameIt }
 }
 
 function cliReveal(payload, password, op) {
@@ -175,7 +175,7 @@ program
       return;
     }
 
-    const questions = [{ type: 'string', message: 'Enter message to decrypt:', name: 'payload' }, {
+    const questions = [{ type: 'input', message: 'Enter message to decrypt:', name: 'payload' }, {
       type: 'password',
       message: 'Enter password :',
       name: 'password',


### PR DESCRIPTION
## Summary
- use `input` type in CLI helper
- adjust reveal prompt to use `input`

## Testing
- `npm test`
- `STEGCLOAK_PASSWORD=testpass node cli.js hide` *(fails: Couldn't find the `xsel` binary)*
- `STEGCLOAK_PASSWORD=testpass node cli.js reveal` *(fails: Invisible stream not detected)*


------
https://chatgpt.com/codex/tasks/task_b_68a80f7bba548325a270628f10d5d9c4