### PR TITLE
Preserve whitespace when embedding secrets

### DIFF
--- a/components/message.js
+++ b/components/message.js
@@ -119,14 +119,13 @@ const zwcOperations = (zwc) => {
 // An optional RNG can be supplied for deterministic behaviour in tests.
 // The RNG should be a function that mimics Math.random.
 const embed = (cover, secret, rng = Math.random) => {
-  const arr = cover.split(" ");
+  const arr = cover.split(/(\s+)/);
+  const wordCount = Math.ceil(arr.length / 2);
   // Ensure we pick an index that has a following word available
-  const targetIndex = Math.floor(rng() * (arr.length - 1));
-  return arr
-    .slice(0, targetIndex + 1)
-    .concat([secret + arr[targetIndex + 1]])
-    .concat(arr.slice(targetIndex + 2, arr.length))
-    .join(" ");
+  const targetWordIndex = Math.floor(rng() * (wordCount - 1));
+  const targetIndex = targetWordIndex * 2 + 2;
+  arr[targetIndex] = secret + arr[targetIndex];
+  return arr.join("");
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "node test/detach.test.js && node test/expand.test.js"
+    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/embed.test.js
+++ b/test/embed.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { embed } = require('../components/message.js');
+
+const secret = 'secret';
+const rng = () => 0; // deterministic to target second word
+
+const covers = [
+  'hello  world again',
+  'hello\tworld\tagain',
+  'hello\nworld\nagain',
+  'hello \t\nworld  \n\tagain',
+];
+
+covers.forEach((cover, idx) => {
+  const result = embed(cover, secret, rng);
+  const expected = cover.replace(/(\s+)(\S+)/, `$1${secret}$2`);
+  assert.strictEqual(
+    result,
+    expected,
+    `embed should preserve whitespace for case ${idx + 1}`
+  );
+});
+
+console.log('All tests passed.');
+
+process.exit(0);
+


### PR DESCRIPTION
## Summary
- Ensure `embed` splits and joins using whitespace-aware regex to keep original spacing
- Cover tabs, newlines, and repeated spaces with new tests and run them via npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8ddf573ec83258f657ae911553869