### PR TITLE
Ensure CLI spinners stop on errors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,7 @@ function cliHide(secret, password, cover, crypt, integrity, op) {
   try {
     payload = stegcloak.hide(secret, password, cover)
   } catch (e) {
+    spinner.stop()
     console.log('\n')
     console.log(chalk.red(e))
     process.exit(0)
@@ -63,6 +64,7 @@ function cliReveal(payload, password, op) {
   try {
     secret = stegcloak.reveal(payload, password)
   } catch (e) {
+    spinner.stop()
     console.log('\n')
     console.log(chalk.red(e))
     process.exit(0)
@@ -233,3 +235,5 @@ program
   })
 
 program.parse(process.argv)
+
+module.exports = { cliHide, cliReveal }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js"
+    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/cli-spinner.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/cli-spinner.test.js
+++ b/test/cli-spinner.test.js
@@ -1,0 +1,69 @@
+const assert = require('assert')
+const Module = require('module')
+
+const originalLoad = Module._load
+const originalExit = process.exit
+const originalArgv = process.argv
+
+let current = null
+let hideStopped = false
+let revealStopped = false
+
+Module._load = function (request, parent, isMain) {
+  if (request === 'ora') {
+    return () => ({
+      start () {},
+      stop () {
+        if (current === 'hide') hideStopped = true
+        if (current === 'reveal') revealStopped = true
+      }
+    })
+  }
+  if (request === './stegcloak') {
+    function FakeStegCloak () {}
+    FakeStegCloak.zwc = ['\u200c', '\u200d', '\u200b']
+    FakeStegCloak.prototype.hide = () => { throw new Error('fail hide') }
+    FakeStegCloak.prototype.reveal = () => { throw new Error('fail reveal') }
+    return FakeStegCloak
+  }
+  if (request === 'clipboardy') {
+    return { writeSync () {}, readSync () { return '' } }
+  }
+  if (request === 'commander') {
+    return {
+      program: {
+        command () { return this },
+        option () { return this },
+        action () { return this },
+        parse () {}
+      }
+    }
+  }
+  return originalLoad(request, parent, isMain)
+}
+
+process.exit = () => { throw new Error('exit') }
+
+const { cliHide, cliReveal } = require('../cli.js')
+
+try {
+  current = 'hide'
+  cliHide('secret', 'password', 'cover', true, false)
+} catch (e) {
+  if (e.message !== 'exit') throw e
+}
+
+try {
+  current = 'reveal'
+  cliReveal('payload', 'password')
+} catch (e) {
+  if (e.message !== 'exit') throw e
+}
+
+process.exit = originalExit
+process.argv = originalArgv
+Module._load = originalLoad
+
+assert.ok(hideStopped, 'cliHide did not stop spinner on error')
+assert.ok(revealStopped, 'cliReveal did not stop spinner on error')
+console.log('CLI spinner error handling tests passed')


### PR DESCRIPTION
## Summary
- stop CLI spinners before exiting on hide/reveal errors
- add spinner failure tests to verify clean shutdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8dff969d48325be79585557dac813