### PR TITLE
Validate binary length in dataToZWC

### DIFF
--- a/components/message.js
+++ b/components/message.js
@@ -25,6 +25,9 @@ const zwcOperations = (zwc) => {
   // Data to ZWC hidden string
 
   const _dataToZWC = (integrity, crypt, str) => {
+    if (str.length % 2 !== 0) {
+      throw new Error("Binary string length must be even");
+    }
     const flag = integrity && crypt ? zwc[0] : crypt ? zwc[1] : zwc[2];
     return (
       flag +

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/cli-spinner.test.js"
+    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/datatozwc.test.js && node test/cli-spinner.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/datatozwc.test.js
+++ b/test/datatozwc.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const StegCloak = require('../stegcloak.js');
+const { zwcOperations } = require('../components/message.js');
+
+const zwc = StegCloak.zwc;
+const { toConceal } = zwcOperations(zwc);
+
+assert.throws(
+  () => toConceal('1'),
+  /Binary string length must be even/,
+  'toConceal should reject odd-length binary input'
+);
+
+console.log('Odd-length binary input rejection test passed');
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- ensure `_dataToZWC` rejects odd-length binary strings
- add test covering odd-length binary input

## Testing
- `npm test` *(terminated after verifying output due to hanging cli-spinner test)*

------
https://chatgpt.com/codex/tasks/task_b_68a8e50c0c388325b529553a5b0023a5