### PR TITLE
Handle reveal without hidden payload gracefully

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -196,7 +196,13 @@ program
 
       data = data || clipboardy.readSync()
 
-      const stream = expand(detach(data))
+      let stream
+      try {
+        stream = expand(detach(data))
+      } catch (e) {
+        console.log(chalk.red('No hidden payload found in provided text.'))
+        process.exit(0)
+      }
 
       if (stream[0] === StegCloak.zwc[2] || process.env["STEGCLOAK_PASSWORD"]) {
         if (process.env["STEGCLOAK_PASSWORD"]) {
@@ -216,7 +222,13 @@ program
 
     else {
       inquirer.prompt([questions[0]]).then(answers => {
-        const stream = expand(detach(answers.payload))
+        let stream
+        try {
+          stream = expand(detach(answers.payload))
+        } catch (e) {
+          console.log(chalk.red('No hidden payload found in provided text.'))
+          process.exit(0)
+        }
 
         if (stream[0] === StegCloak.zwc[2]) {
           cliReveal(answers.payload, null, args.output)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/cli-spinner.test.js"
+    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/reveal-no-payload.test.js && node test/cli-spinner.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/reveal-no-payload.test.js
+++ b/test/reveal-no-payload.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const StegCloak = require('../stegcloak.js');
+
+const stegcloak = new StegCloak();
+
+assert.throws(() => {
+  stegcloak.reveal('nothing hidden here');
+}, /Invisible stream not detected/, 'reveal should throw when no hidden payload is present');
+
+console.log('Reveal without hidden payload test passed');
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- exit with message when `stegcloak reveal` is given text with no hidden payload
- test revealing from text without a hidden payload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8e32693708325aefc01a9b70ed858