### PR TITLE
Use non-zero exit codes for CLI errors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,7 @@ function cliHide(secret, password, cover, crypt, integrity, op) {
 
   if (crypt && !password) {
     console.log(chalk.red('Error: A password is required for encryption'))
-    process.exit(0)
+    process.exit(1)
   }
 
   const spinner = ora(chalk.cyan.bold('Hiding your text'))
@@ -37,7 +37,7 @@ function cliHide(secret, password, cover, crypt, integrity, op) {
     spinner.stop()
     console.log('\n')
     console.log(chalk.red(e))
-    process.exit(0)
+    process.exit(1)
   }
   clipboardy.writeSync(payload)
   setTimeout(() => {
@@ -67,7 +67,7 @@ function cliReveal(payload, password, op) {
     spinner.stop()
     console.log('\n')
     console.log(chalk.red(e))
-    process.exit(0)
+    process.exit(1)
   }
   setTimeout(() => {
     spinner.stop()
@@ -94,10 +94,10 @@ program
     if (args.config) {
       jsonfile.readFile(args.config)
         .then(obj => {
-          if (!("secret" in obj && "cover" in obj)) {
-            console.error(chalk.red("Config Parse error") + " : Missing inputs");
-            process.exit(0);
-          }
+        if (!("secret" in obj && "cover" in obj)) {
+          console.error(chalk.red("Config Parse error") + " : Missing inputs");
+          process.exit(1);
+        }
           secret = obj.secret;
           cover = obj.cover;
           let password = obj.password || process.env["STEGCLOAK_PASSWORD"];
@@ -161,10 +161,10 @@ program
     if (args.config) {
       jsonfile.readFile(args.config)
         .then(obj => {
-          if (!("message" in obj)) {
-            console.error(chalk.red("Config Parse error") + " : Missing inputs");
-            process.exit(0);
-          }
+        if (!("message" in obj)) {
+          console.error(chalk.red("Config Parse error") + " : Missing inputs");
+          process.exit(1);
+        }
           data = obj.message;
           if (!obj.password && process.env["STEGCLOAK_PASSWORD"]) {
             console.warn(chalk.yellow("Warning:") + " using password from environment variable");

--- a/test/cli-spinner.test.js
+++ b/test/cli-spinner.test.js
@@ -8,6 +8,8 @@ const originalArgv = process.argv
 let current = null
 let hideStopped = false
 let revealStopped = false
+let hideExitCode = null
+let revealExitCode = null
 
 Module._load = function (request, parent, isMain) {
   if (request === 'ora') {
@@ -42,7 +44,11 @@ Module._load = function (request, parent, isMain) {
   return originalLoad(request, parent, isMain)
 }
 
-process.exit = () => { throw new Error('exit') }
+process.exit = (code) => {
+  if (current === 'hide') hideExitCode = code
+  if (current === 'reveal') revealExitCode = code
+  throw new Error('exit')
+}
 
 const { cliHide, cliReveal } = require('../cli.js')
 
@@ -66,4 +72,7 @@ Module._load = originalLoad
 
 assert.ok(hideStopped, 'cliHide did not stop spinner on error')
 assert.ok(revealStopped, 'cliReveal did not stop spinner on error')
+assert.strictEqual(hideExitCode, 1, 'cliHide did not exit with code 1 on error')
+assert.strictEqual(revealExitCode, 1, 'cliReveal did not exit with code 1 on error')
 console.log('CLI spinner error handling tests passed')
+process.exit(0)


### PR DESCRIPTION
## Summary
- return exit code 1 for CLI error paths like missing password or config parse failures
- verify CLI exit codes in spinner tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a8f9e956dc83258f15d3fc4712c890