### PR TITLE
docs: enhance code comments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,8 +23,16 @@ const { expand } = zwcHuffMan(StegCloak.zwc)
 const { detach } = zwcOperations(StegCloak.zwc);
 
 
-// Hide a secret message using supplied options and optionally copy or write
-// the result.  Acts as the implementation behind the `hide` command.
+/**
+ * Hide a secret message using supplied options and optionally copy or write
+ * the result. Acts as the implementation behind the `hide` command.
+ * @param {string} secret Message to conceal.
+ * @param {string} password Password used for encryption when `crypt` is true.
+ * @param {string} cover Visible cover text.
+ * @param {boolean} crypt Whether to encrypt the message.
+ * @param {boolean} integrity Enable HMAC integrity protection.
+ * @param {string} [op] Optional output file path.
+ */
 function cliHide(secret, password, cover, crypt, integrity, op) {
   const stegcloak = new StegCloak(crypt, integrity)
 
@@ -57,12 +65,22 @@ function cliHide(secret, password, cover, crypt, integrity, op) {
   }, 300)
 };
 
-// Small helper to build Inquirer question objects
+/**
+ * Small helper to build Inquirer question objects.
+ * @param {string} str Prompt message.
+ * @param {string} nameIt Name of the property for the answer object.
+ * @returns {Object} Inquirer question configuration.
+ */
 function createStringQuestion(str, nameIt) {
   return { type: 'input', message: str, name: nameIt }
 }
 
-// Reveal and display a hidden message. Mirrors `cliHide` but for extraction.
+/**
+ * Reveal and display a hidden message. Mirrors {@link cliHide} but for extraction.
+ * @param {string} payload Text containing the concealed secret.
+ * @param {string} [password] Password used for decryption.
+ * @param {string} [op] Optional output file path for the revealed secret.
+ */
 function cliReveal(payload, password, op) {
   const stegcloak = new StegCloak()
   var spinner = ora(chalk.cyan.bold('Decrypting'))

--- a/components/compact.js
+++ b/components/compact.js
@@ -13,7 +13,11 @@ const { recursiveReplace } = require("./util");
 
 const lzutf8 = require("lzutf8");
 
-// Compress plain text into a Buffer using LZUTF8
+/**
+ * Compress plain text into a Buffer using LZUTF8.
+ * @param {string} x String to compress.
+ * @returns {Buffer} Compressed output.
+ */
 const compress = (x) =>
   lzutf8.compress(x, {
     outputEncoding: "Buffer",
@@ -25,11 +29,20 @@ const _lzutf8Decompress = curry(lzutf8.decompress)(__, {
   outputEncoding: "String",
 });
 
-// Decompress a Buffer back into a string
+/**
+ * Decompress a Buffer back into a string.
+ * @param {Buffer} data Buffer to decompress.
+ * @returns {string} Decompressed string.
+ */
 const decompress = pipe(Buffer.from, _lzutf8Decompress);
 
-// Build a ranking table to determine which two characters benefit most from
-// compression. Returns the optimal pair sorted alphabetically.
+/**
+ * Determine which two characters in the provided alphabet are repeated most.
+ * Used to decide which characters should be replaced by compression flags.
+ * @param {string} secret The string to analyse.
+ * @param {string[]} characters Candidate zero width characters.
+ * @returns {string[]} Two characters sorted alphabetically.
+ */
 const findOptimal = (secret, characters) => {
   const dict = characters.reduce((acc, data) => {
     acc[data] = {};
@@ -75,7 +88,11 @@ const findOptimal = (secret, characters) => {
   return reqZwc.slice().sort();
 };
 
-// Generate shrink/expand helpers for a given set of zero width characters.
+/**
+ * Generate shrink/expand helpers for a given set of zero width characters.
+ * @param {string[]} zwc Zero width character table.
+ * @returns {{shrink: Function, expand: Function}} Compression helpers.
+ */
 const zwcHuffMan = (zwc) => {
   const tableMap = [
     zwc[0] + zwc[1],
@@ -93,7 +110,11 @@ const zwcHuffMan = (zwc) => {
 
   const _extractCompressFlag = (zwc1) => tableMap[zwc.indexOf(zwc1)].split(""); // zwcD => zwA,zwcB
 
-  // Replace repeated characters with flags to shrink the stream
+  /**
+   * Replace repeated characters with compression flags to shrink the stream.
+   * @param {string} secret Zero width character stream.
+   * @returns {string} Compressed stream.
+   */
   const shrink = (secret) => {
     const repeatChars = findOptimal(secret, zwc.slice(0, 4));
     return (
@@ -106,7 +127,11 @@ const zwcHuffMan = (zwc) => {
     );
   };
 
-  // Expand a compressed stream back to its original form
+  /**
+   * Expand a compressed zero width stream back to its original form.
+   * @param {string} secret Compressed stream.
+   * @returns {string} Decompressed stream.
+   */
   const expand = (secret) => {
     if (!secret) {
       return secret;

--- a/components/message.js
+++ b/components/message.js
@@ -20,6 +20,11 @@ const {
 
 const { zeroPad, nTobin, stepMap, binToByte } = require("./util.js");
 
+/**
+ * Factory creating helpers for working with zero width character streams.
+ * @param {string[]} zwc Array of zero width characters used for encoding.
+ * @returns {{detach: Function, concealToData: Function, toConcealHmac: Function, toConceal: Function, noCrypt: Function}}
+ */
 const zwcOperations = (zwc) => {
   // Map binary to its corresponding zero width character
   const _binToZWC = (str) => zwc[parseInt(str, 2)];
@@ -74,7 +79,11 @@ const zwcOperations = (zwc) => {
 
   const noCrypt = curry(_dataToZWC)(false)(false);
 
-  // Convert a zero width string back into binary data
+  /**
+   * Convert a zero width string back into binary data with flag analysis.
+   * @param {string} str Zero width character string to decode.
+   * @returns {{encrypt: boolean, integrity: boolean, data: Uint8Array}}
+   */
   const concealToData = (str) => {
     let encrypt, integrity;
     try {
@@ -95,7 +104,11 @@ const zwcOperations = (zwc) => {
     };
   };
 
-  // Extract the first word containing zero width characters from a string
+  /**
+   * Extract the first word containing zero width characters from a string.
+   * @param {string} str Cover text potentially containing hidden data.
+   * @returns {string} Detected zero width segment.
+   */
   const detach = (str) => {
     const eachWords = str.split(/\s+/).filter(Boolean);
     for (const word of eachWords) {
@@ -120,10 +133,14 @@ const zwcOperations = (zwc) => {
   };
 };
 
-// Embed invisble stream to cover text
-
-// An optional RNG can be supplied for deterministic behaviour in tests.
-// The RNG should be a function that mimics Math.random.
+/**
+ * Embed a hidden zero width stream into a cover text.
+ * An optional RNG can be supplied for deterministic behaviour in tests.
+ * @param {string} cover Visible text that will carry the secret.
+ * @param {string} secret Zero width character stream to embed.
+ * @param {Function} [rng=Math.random] Random number generator used to pick the insertion point.
+ * @returns {string} Cover text with embedded secret.
+ */
 const embed = (cover, secret, rng = Math.random) => {
   const arr = cover.split(/(\s+)/);
   const wordCount = Math.ceil(arr.length / 2);

--- a/components/util.js
+++ b/components/util.js
@@ -23,25 +23,56 @@ const {
 // Compliment a byte and ensure values stay in the 0-255 range
 const _not = (x) => (~x) & 0xff;
 
-// Slice a buffer
+/**
+ * Slice a buffer or byte array.
+ * @param {Buffer|Uint8Array} x Source buffer.
+ * @param {number} y Start index (inclusive).
+ * @param {number} [z=x.length] End index (exclusive).
+ * @returns {Buffer} New sliced buffer.
+ */
 const buffSlice = (x, y, z = x.length) => pipe(byarr, slice(y, z), toBuffer)(x);
 
-// Concatenate buffers
+/**
+ * Concatenate an array of Buffers into a single Buffer.
+ * @type {Function}
+ */
 const concatBuff = Buffer.concat;
 
-// Convert byte array to buffer
+/**
+ * Convert a byte array into a Buffer.
+ * @type {Function}
+ */
 const toBuffer = Buffer.from;
 
-// Convert buffer to byte array
-const byarr = (x) => Uint8Array.from(x); // Cannot be point-free since Uint8Array.from() needs to be bound to its prototype
+/**
+ * Convert a Buffer into a Uint8Array.
+ * Cannot be point-free since {@link Uint8Array.from} must be bound.
+ * @param {Buffer} x Source buffer.
+ * @returns {Uint8Array} Byte array representation.
+ */
+const byarr = (x) => Uint8Array.from(x);
 
-// Number to binary string conversion
+/**
+ * Convert a number into its binary string representation.
+ * @param {number} x Number to convert.
+ * @returns {string} Binary string.
+ */
 const nTobin = (x) => x.toString(2);
 
-// Convert to byte array and apply complement
+/**
+ * Compliment the bytes in a buffer.
+ * @param {Buffer} input Buffer to compliment.
+ * @returns {Uint8Array} Complimented byte array.
+ */
 const compliment = pipe(byarr, map(_not));
 
-// Map over an array in fixed-size steps
+/**
+ * Map over an array in fixed-size steps.
+ * @param {Function} callback Function executed for each step.
+ * @param {number} step Number of elements to skip per iteration.
+ * @param {Array} array Array to iterate over.
+ * @returns {Array} New array containing mapped values.
+ */
 const stepMap = curry((callback, step, array) => {
   return array
     .map((d, i, array) => {
@@ -52,7 +83,13 @@ const stepMap = curry((callback, step, array) => {
     .filter((d, i) => i % step === 0);
 });
 
-// Pure recursive regular expression replace
+/**
+ * Recursively perform global replacements on a string.
+ * @param {string} data Source string.
+ * @param {string[]} patternArray Patterns to replace, processed from end to start.
+ * @param {string[]} replaceArray Replacement strings corresponding to patterns.
+ * @returns {string} Resulting string after all replacements.
+ */
 const recursiveReplace = (data, patternArray, replaceArray) => {
   if (isEmpty(patternArray) && isEmpty(replaceArray)) {
     return data;
@@ -67,7 +104,12 @@ const recursiveReplace = (data, patternArray, replaceArray) => {
   );
 };
 
-// Pad with zeroes to get required length
+/**
+ * Pad a number with leading zeroes to a specified width.
+ * @param {number} x Desired width.
+ * @param {number} num Number to pad.
+ * @returns {string} Zero-padded string.
+ */
 const zeroPad = curry((x, num) => {
   var zero = "";
   for (let i = 0; i < x; i++) {
@@ -76,10 +118,18 @@ const zeroPad = curry((x, num) => {
   return zero.slice(String(num).length) + num;
 });
 
-// Byte array to binary string conversion. Ensure input bytes are unsigned.
+/**
+ * Convert a Buffer into a binary string. Input bytes are treated as unsigned.
+ * @param {Buffer|Uint8Array} input Buffer to convert.
+ * @returns {string} Binary representation.
+ */
 const byteToBin = pipe(byarr, Array.from, map(nTobin), map(zeroPad(8)), join(""));
 
-// Binary string to byte array conversion
+/**
+ * Convert a binary string into a Uint8Array of bytes.
+ * @param {string} str Binary string where length is a multiple of eight.
+ * @returns {Uint8Array} Parsed bytes.
+ */
 const binToByte = (str) => {
   var arr = [];
   for (let i = 0; i < str.length; i += 8) {

--- a/stegcloak.js
+++ b/stegcloak.js
@@ -50,7 +50,15 @@ const {
   compliment
 } = require("./components/util");
 
+/**
+ * Core class exposing the public API for hiding and revealing messages.
+ */
 class StegCloak {
+  /**
+   * Create a new StegCloak instance.
+   * @param {boolean} [_encrypt=true] Enable encryption of the payload.
+   * @param {boolean} [_integrity=false] Enable HMAC integrity protection.
+   */
   constructor(_encrypt = true, _integrity = false) {
     // By default encryption is enabled and integrity (HMAC) disabled
     this.encrypt = _encrypt;
@@ -59,6 +67,10 @@ class StegCloak {
     this.integrity = _integrity;
   }
 
+  /**
+   * Expose the zero width character table used for encoding.
+   * @returns {string[]} Array of zero width characters.
+   */
   static get zwc() {
     return zwc;
   }


### PR DESCRIPTION
## Summary
- document utility helpers with JSDoc
- clarify compression and zero-width helpers with better comments
- add API docs to CLI and core StegCloak class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b635d90e348325bc5a575af8e2e222