### PR TITLE
Enhance inline documentation across StegCloak

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,8 +23,17 @@ const { expand } = zwcHuffMan(StegCloak.zwc)
 const { detach } = zwcOperations(StegCloak.zwc);
 
 
-// Hide a secret message using supplied options and optionally copy or write
-// the result.  Acts as the implementation behind the `hide` command.
+/**
+ * Hide a secret message using supplied options and optionally copy or write
+ * the result. Acts as the implementation behind the `hide` command.
+ *
+ * @param {string} secret     Message to conceal.
+ * @param {string} password   Password for encryption when enabled.
+ * @param {string} cover      Text that will host the secret.
+ * @param {boolean} crypt     Toggle for encryption.
+ * @param {boolean} integrity Enable HMAC integrity protection.
+ * @param {string} [op]       Optional file path to write the result.
+ */
 function cliHide(secret, password, cover, crypt, integrity, op) {
   const stegcloak = new StegCloak(crypt, integrity)
 
@@ -57,12 +66,24 @@ function cliHide(secret, password, cover, crypt, integrity, op) {
   }, 300)
 };
 
-// Small helper to build Inquirer question objects
+/**
+ * Small helper to build Inquirer question objects.
+ *
+ * @param {string} str     Prompt text.
+ * @param {string} nameIt  Key used in the resulting answers object.
+ * @returns {{type: string, message: string, name: string}} Question configuration.
+ */
 function createStringQuestion(str, nameIt) {
   return { type: 'input', message: str, name: nameIt }
 }
 
-// Reveal and display a hidden message. Mirrors `cliHide` but for extraction.
+/**
+ * Reveal and display a hidden message. Mirrors {@link cliHide} but for extraction.
+ *
+ * @param {string} payload  Cover text containing the secret.
+ * @param {string} password Password for decrypting the payload.
+ * @param {string} [op]     Optional file path to write the revealed secret.
+ */
 function cliReveal(payload, password, op) {
   const stegcloak = new StegCloak()
   var spinner = ora(chalk.cyan.bold('Decrypting'))

--- a/components/compact.js
+++ b/components/compact.js
@@ -13,7 +13,12 @@ const { recursiveReplace } = require("./util");
 
 const lzutf8 = require("lzutf8");
 
-// Compress plain text into a Buffer using LZUTF8
+/**
+ * Compress plain text into a Buffer using LZUTF8.
+ *
+ * @param {string} x Text to be compressed.
+ * @returns {Buffer} Compressed representation of the input text.
+ */
 const compress = (x) =>
   lzutf8.compress(x, {
     outputEncoding: "Buffer",
@@ -25,11 +30,24 @@ const _lzutf8Decompress = curry(lzutf8.decompress)(__, {
   outputEncoding: "String",
 });
 
-// Decompress a Buffer back into a string
+/**
+ * Decompress a Buffer back into a string.
+ *
+ * @param {Buffer|Uint8Array|string} x Compressed data produced by {@link compress}.
+ * @returns {string} The original uncompressed text.
+ */
 const decompress = pipe(Buffer.from, _lzutf8Decompress);
 
-// Build a ranking table to determine which two characters benefit most from
-// compression. Returns the optimal pair sorted alphabetically.
+/**
+ * Build a ranking table to determine which two characters benefit most from
+ * compression.
+ *
+ * Returns the optimal pair sorted alphabetically.
+ *
+ * @param {string} secret     Zero width character stream.
+ * @param {string[]} characters Candidate zero width characters to analyse.
+ * @returns {string[]} Two character array representing the best compression pair.
+ */
 const findOptimal = (secret, characters) => {
   const dict = characters.reduce((acc, data) => {
     acc[data] = {};
@@ -75,7 +93,12 @@ const findOptimal = (secret, characters) => {
   return reqZwc.slice().sort();
 };
 
-// Generate shrink/expand helpers for a given set of zero width characters.
+/**
+ * Generate shrink/expand helpers for a given set of zero width characters.
+ *
+ * @param {string[]} zwc Array of zero width characters used for encoding.
+ * @returns {{shrink: function(string): string, expand: function(string): string}} Object containing helper functions.
+ */
 const zwcHuffMan = (zwc) => {
   const tableMap = [
     zwc[0] + zwc[1],

--- a/components/encrypt.js
+++ b/components/encrypt.js
@@ -20,9 +20,16 @@ const { toBuffer, concatBuff, buffSlice } = require("./util.js");
 const _genKey = (password, salt) =>
   pbkdf2Sync(password, salt, 10000, 48, "sha512");
 
-// AES stream cipher with random salt and IV.  Expects an object
-// `{password, data, integrity}` and returns an encrypted Buffer.  When
-// `integrity` is true, an HMAC of the plaintext is prepended to the output.
+/**
+ * AES stream cipher with random salt and IV.
+ *
+ * Expects an object `{password, data, integrity}` and returns an encrypted
+ * Buffer. When `integrity` is true, an HMAC of the plaintext is prepended to
+ * the output.
+ *
+ * @param {{password: string, data: Buffer|string, integrity: boolean}} config Encryption options.
+ * @returns {Buffer} Encrypted payload including salt and optional HMAC.
+ */
 const encrypt = (config) => {
   // Impure function – generates random bytes for salt and IV.
   const salt = randomBytes(16);
@@ -36,8 +43,14 @@ const encrypt = (config) => {
   return concatBuff([salt, payload]);
 };
 
-// Reverse of `encrypt`. Validates HMAC when requested and returns the
-// decrypted Buffer. Throws on integrity failure or malformed input.
+/**
+ * Reverse of {@link encrypt}. Validates HMAC when requested and returns the
+ * decrypted Buffer. Throws on integrity failure or malformed input.
+ *
+ * @param {{password: string, data: Buffer|string, integrity: boolean}} config Decryption options.
+ * @returns {Buffer} Decrypted plaintext buffer.
+ * @throws {Error} If integrity validation fails or payload is malformed.
+ */
 const decrypt = (config) => {
   const { iv, key, secret, hmacData } = _bootDecrypt(config, null);
   const decipher = createDecipheriv("aes-256-ctr", key, iv);

--- a/components/message.js
+++ b/components/message.js
@@ -20,6 +20,14 @@ const {
 
 const { zeroPad, nTobin, stepMap, binToByte } = require("./util.js");
 
+/**
+ * Factory that returns helpers for converting data to and from zero width
+ * character streams.
+ *
+ * @param {string[]} zwc Array of zero width characters used for encoding.
+ * @returns {{detach: function(string): string, concealToData: function(string): object, toConcealHmac: function(string): string, toConceal: function(string): string, noCrypt: function(string): string}}
+ * Object exposing conversion utilities.
+ */
 const zwcOperations = (zwc) => {
   // Map binary to its corresponding zero width character
   const _binToZWC = (str) => zwc[parseInt(str, 2)];
@@ -120,10 +128,17 @@ const zwcOperations = (zwc) => {
   };
 };
 
-// Embed invisble stream to cover text
-
-// An optional RNG can be supplied for deterministic behaviour in tests.
-// The RNG should be a function that mimics Math.random.
+/**
+ * Embed an invisible stream into the provided cover text.
+ *
+ * An optional RNG can be supplied for deterministic behaviour in tests. The RNG
+ * should be a function that mimics `Math.random`.
+ *
+ * @param {string} cover Visible text that will hide the secret.
+ * @param {string} secret Zero width character stream to embed.
+ * @param {function} [rng=Math.random] Optional random number generator.
+ * @returns {string} Cover text with the secret inserted.
+ */
 const embed = (cover, secret, rng = Math.random) => {
   const arr = cover.split(/(\s+)/);
   const wordCount = Math.ceil(arr.length / 2);

--- a/components/util.js
+++ b/components/util.js
@@ -23,25 +23,62 @@ const {
 // Compliment a byte and ensure values stay in the 0-255 range
 const _not = (x) => (~x) & 0xff;
 
-// Slice a buffer
+/**
+ * Slice a buffer.
+ *
+ * @param {Buffer|Uint8Array} x Source buffer.
+ * @param {number} y Start index.
+ * @param {number} [z=x.length] End index (non-inclusive).
+ * @returns {Buffer} New buffer containing the requested slice.
+ */
 const buffSlice = (x, y, z = x.length) => pipe(byarr, slice(y, z), toBuffer)(x);
 
-// Concatenate buffers
+/**
+ * Concatenate multiple buffers.
+ *
+ * @type {function(Buffer[]): Buffer}
+ */
 const concatBuff = Buffer.concat;
 
-// Convert byte array to buffer
+/**
+ * Convert a byte array into a Buffer instance.
+ *
+ * @type {function(Array|ArrayBuffer|Uint8Array|string): Buffer}
+ */
 const toBuffer = Buffer.from;
 
-// Convert buffer to byte array
+/**
+ * Convert buffer to byte array.
+ *
+ * @param {Buffer|Uint8Array} x Buffer to convert.
+ * @returns {Uint8Array} Byte array representation.
+ */
 const byarr = (x) => Uint8Array.from(x); // Cannot be point-free since Uint8Array.from() needs to be bound to its prototype
 
-// Number to binary string conversion
+/**
+ * Number to binary string conversion.
+ *
+ * @param {number} x Number to convert.
+ * @returns {string} Binary representation of the number.
+ */
 const nTobin = (x) => x.toString(2);
 
-// Convert to byte array and apply complement
+/**
+ * Convert input to a byte array and apply bitwise complement.
+ *
+ * @param {Buffer|Uint8Array|string} x Data to complement.
+ * @returns {Uint8Array} Complemented byte array.
+ */
 const compliment = pipe(byarr, map(_not));
 
-// Map over an array in fixed-size steps
+/**
+ * Map over an array in fixed-size steps.
+ *
+ * @param {function} callback Function applied to each step.
+ * @param {number} step Size of each step.
+ * @param {Array} array Input array.
+ * @returns {Array} Result of mapping.
+ */
 const stepMap = curry((callback, step, array) => {
   return array
     .map((d, i, array) => {
@@ -52,7 +89,14 @@ const stepMap = curry((callback, step, array) => {
     .filter((d, i) => i % step === 0);
 });
 
-// Pure recursive regular expression replace
+/**
+ * Pure recursive regular expression replace.
+ *
+ * @param {string} data         Source string.
+ * @param {string[]} patternArray  Patterns to replace.
+ * @param {string[]} replaceArray  Replacement strings.
+ * @returns {string} Mutated string with replacements applied.
+ */
 const recursiveReplace = (data, patternArray, replaceArray) => {
   if (isEmpty(patternArray) && isEmpty(replaceArray)) {
     return data;
@@ -67,7 +111,13 @@ const recursiveReplace = (data, patternArray, replaceArray) => {
   );
 };
 
-// Pad with zeroes to get required length
+/**
+ * Pad a number with leading zeroes to achieve the required length.
+ *
+ * @param {number} x   Desired length.
+ * @param {number|string} num Number to pad.
+ * @returns {string} Padded string.
+ */
 const zeroPad = curry((x, num) => {
   var zero = "";
   for (let i = 0; i < x; i++) {
@@ -76,10 +126,20 @@ const zeroPad = curry((x, num) => {
   return zero.slice(String(num).length) + num;
 });
 
-// Byte array to binary string conversion. Ensure input bytes are unsigned.
+/**
+ * Byte array to binary string conversion. Ensures input bytes are unsigned.
+ *
+ * @param {Buffer|Uint8Array|string} x Data to convert.
+ * @returns {string} Binary string representation.
+ */
 const byteToBin = pipe(byarr, Array.from, map(nTobin), map(zeroPad(8)), join(""));
 
-// Binary string to byte array conversion
+/**
+ * Binary string to byte array conversion.
+ *
+ * @param {string} str Binary string.
+ * @returns {Uint8Array} Byte array.
+ */
 const binToByte = (str) => {
   var arr = [];
   for (let i = 0; i < str.length; i += 8) {


### PR DESCRIPTION
## Summary
- add extensive JSDoc comments to core StegCloak class and helpers
- clarify behaviour of compression, encryption and messaging components
- document CLI helper functions for easier maintenance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b636b6e7bc8325995b36a4d0056a69