### PR TITLE
Handle single-word covers in embed

### DIFF
--- a/components/message.js
+++ b/components/message.js
@@ -144,6 +144,9 @@ const zwcOperations = (zwc) => {
 const embed = (cover, secret, rng = Math.random) => {
   const arr = cover.split(/(\s+)/);
   const wordCount = Math.ceil(arr.length / 2);
+  if (wordCount < 2) {
+    throw new Error("Cover text must contain at least two words");
+  }
   // Ensure we pick an index that has a following word available
   const targetWordIndex = Math.floor(rng() * (wordCount - 1));
   const targetIndex = targetWordIndex * 2 + 2;

--- a/test/embed.test.js
+++ b/test/embed.test.js
@@ -22,6 +22,13 @@ covers.forEach((cover, idx) => {
   );
 });
 
+// Single-word cover should produce a clear error
+assert.throws(
+  () => embed('hello', secret, rng),
+  /Cover text must contain at least two words/,
+  'embed should throw an error when cover has fewer than two words'
+);
+
 console.log('All tests passed.');
 
 process.exit(0);


### PR DESCRIPTION
## Summary
- prevent embedding when cover text has fewer than two words
- add test asserting single-word covers trigger a descriptive error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6428cfb5c83259b4e3801366fd494