### PR TITLE
Improve CLI error handling for file and clipboard failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/reveal-no-payload.test.js && node test/cli-spinner.test.js && node test/hide-missing-password.test.js && node test/reveal-missing-password.test.js && node test/nocrypt-hide-reveal.test.js && node test/encrypt-salt.test.js && node test/integrity-without-crypt.test.js && node test/cli-integrity-nocrypt.test.js && node test/encrypt-binary-data.test.js"
+    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/reveal-no-payload.test.js && node test/cli-spinner.test.js && node test/hide-missing-password.test.js && node test/reveal-missing-password.test.js && node test/nocrypt-hide-reveal.test.js && node test/encrypt-salt.test.js && node test/integrity-without-crypt.test.js && node test/cli-integrity-nocrypt.test.js && node test/encrypt-binary-data.test.js && node test/cli-file-read-error.test.js && node test/cli-clipboard-read-error.test.js && node test/cli-clipboard-write-error.test.js && node test/cli-fs-write-error.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/cli-clipboard-read-error.test.js
+++ b/test/cli-clipboard-read-error.test.js
@@ -1,0 +1,38 @@
+// Ensure CLI handles clipboard read failures gracefully
+const assert = require('assert')
+const Module = require('module')
+const path = require('path')
+
+const originalLoad = Module._load
+const originalExit = process.exit
+const originalArgv = process.argv
+let exitCode = null
+
+Module._load = function (request, parent, isMain) {
+  if (request === 'clipboardy') {
+    return { readSync () { throw new Error('clipboard read fail') }, writeSync () {} }
+  }
+  return originalLoad(request, parent, isMain)
+}
+
+process.exit = (code) => {
+  exitCode = code
+  throw new Error('exit')
+}
+
+process.argv = ['node', path.join(__dirname, '../cli.js'), 'reveal', '--clip']
+
+try {
+  require('../cli.js')
+} catch (e) {
+  if (e.message !== 'exit') throw e
+}
+
+process.exit = originalExit
+process.argv = originalArgv
+Module._load = originalLoad
+
+assert.strictEqual(exitCode, 1, 'CLI did not exit with code 1 on clipboard read error')
+console.log('CLI clipboard read error test passed')
+process.exit(0)
+

--- a/test/cli-clipboard-write-error.test.js
+++ b/test/cli-clipboard-write-error.test.js
@@ -1,0 +1,47 @@
+// Ensure cliHide handles clipboard write failures
+const assert = require('assert')
+const Module = require('module')
+
+const originalLoad = Module._load
+const originalExit = process.exit
+let exitCode = null
+
+Module._load = function (request, parent, isMain) {
+  if (request === 'clipboardy') {
+    return { writeSync () { throw new Error('clipboard write fail') } }
+  }
+  if (request === './stegcloak') {
+    function FakeStegCloak () {}
+    FakeStegCloak.zwc = ['\u200c', '\u200d', '\u200b']
+    FakeStegCloak.prototype.hide = () => 'payload'
+    return FakeStegCloak
+  }
+  if (request === 'ora') {
+    return () => ({ start () {}, stop () {} })
+  }
+  if (request === 'commander') {
+    return { program: { command () { return this }, option () { return this }, action () { return this }, parse () {} } }
+  }
+  return originalLoad(request, parent, isMain)
+}
+
+process.exit = (code) => {
+  exitCode = code
+  throw new Error('exit')
+}
+
+const { cliHide } = require('../cli.js')
+
+try {
+  cliHide('secret', 'password', 'cover', true, false)
+} catch (e) {
+  if (e.message !== 'exit') throw e
+}
+
+process.exit = originalExit
+Module._load = originalLoad
+
+assert.strictEqual(exitCode, 1, 'cliHide did not exit with code 1 on clipboard write error')
+console.log('CLI clipboard write error test passed')
+process.exit(0)
+

--- a/test/cli-file-read-error.test.js
+++ b/test/cli-file-read-error.test.js
@@ -1,0 +1,28 @@
+// Ensure CLI handles missing files gracefully when using --fcover
+const assert = require('assert')
+const path = require('path')
+
+const originalExit = process.exit
+const originalArgv = process.argv
+let exitCode = null
+
+process.exit = (code) => {
+  exitCode = code
+  throw new Error('exit')
+}
+
+process.argv = ['node', path.join(__dirname, '../cli.js'), 'hide', 'secret', '--fcover', 'missing.txt', '--nocrypt']
+
+try {
+  require('../cli.js')
+} catch (e) {
+  if (e.message !== 'exit') throw e
+}
+
+process.exit = originalExit
+process.argv = originalArgv
+
+assert.strictEqual(exitCode, 1, 'CLI did not exit with code 1 on missing file')
+console.log('CLI file read error test passed')
+process.exit(0)
+

--- a/test/cli-fs-write-error.test.js
+++ b/test/cli-fs-write-error.test.js
@@ -1,0 +1,55 @@
+// Ensure cliHide handles file write failures
+const assert = require('assert')
+const Module = require('module')
+
+const originalLoad = Module._load
+const originalExit = process.exit
+const originalSetTimeout = global.setTimeout
+let exitCode = null
+
+Module._load = function (request, parent, isMain) {
+  if (request === 'clipboardy') {
+    return { writeSync () {} }
+  }
+  if (request === 'fs') {
+    return { writeFileSync () { throw new Error('fs write fail') } }
+  }
+  if (request === './stegcloak') {
+    function FakeStegCloak () {}
+    FakeStegCloak.zwc = ['\u200c', '\u200d', '\u200b']
+    FakeStegCloak.prototype.hide = () => 'payload'
+    return FakeStegCloak
+  }
+  if (request === 'ora') {
+    return () => ({ start () {}, stop () {} })
+  }
+  if (request === 'commander') {
+    return { program: { command () { return this }, option () { return this }, action () { return this }, parse () {} } }
+  }
+  return originalLoad(request, parent, isMain)
+}
+
+// Make timers immediate to keep test synchronous
+global.setTimeout = (fn, ms) => { fn(); return 0 }
+
+process.exit = (code) => {
+  exitCode = code
+  throw new Error('exit')
+}
+
+const { cliHide } = require('../cli.js')
+
+try {
+  cliHide('secret', 'password', 'cover', true, false, 'output.txt')
+} catch (e) {
+  if (e.message !== 'exit') throw e
+}
+
+process.exit = originalExit
+Module._load = originalLoad
+global.setTimeout = originalSetTimeout
+
+assert.strictEqual(exitCode, 1, 'cliHide did not exit with code 1 on file write error')
+console.log('CLI file write error test passed')
+process.exit(0)
+


### PR DESCRIPTION
## Summary
- guard against using `--integrity` with `--nocrypt` before hiding
- wrap filesystem and clipboard operations in try/catch with friendly errors
- add CLI tests for file read/write and clipboard failure scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b64a34ba78832586cc938eba0a13a0