### PR TITLE
chore: remove unused Ramda import from CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,6 @@ const {
   program
 } = require('commander')
 const StegCloak = require('./stegcloak')
-const R = require('ramda')
 const chalk = require('chalk')
 const clipboardy = require('clipboardy')
 var inquirer = require('inquirer')


### PR DESCRIPTION
## Summary
- remove unused Ramda import from CLI entrypoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b64e198c348325b08c4996da20eb4d