### PR TITLE
Fix findOptimal loop bounds and add single-char test

### DIFF
--- a/components/compact.js
+++ b/components/compact.js
@@ -51,7 +51,7 @@ const findOptimal = (secret, characters) => {
   const size = secret.length;
   for (let j = 0; j < size; j++) {
     let count = 1;
-    while (j < size && secret[j] === secret[j + 1]) {
+    while (j + 1 < size && secret[j] === secret[j + 1]) {
       count++;
       j++;
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/reveal-no-payload.test.js && node test/cli-spinner.test.js && node test/hide-missing-password.test.js && node test/reveal-missing-password.test.js && node test/nocrypt-hide-reveal.test.js && node test/encrypt-salt.test.js && node test/integrity-without-crypt.test.js && node test/cli-integrity-nocrypt.test.js && node test/encrypt-binary-data.test.js && node test/cli-file-read-error.test.js && node test/cli-clipboard-read-error.test.js && node test/cli-clipboard-write-error.test.js && node test/cli-fs-write-error.test.js"
+    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/reveal-no-payload.test.js && node test/cli-spinner.test.js && node test/hide-missing-password.test.js && node test/reveal-missing-password.test.js && node test/nocrypt-hide-reveal.test.js && node test/encrypt-salt.test.js && node test/integrity-without-crypt.test.js && node test/cli-integrity-nocrypt.test.js && node test/encrypt-binary-data.test.js && node test/cli-file-read-error.test.js && node test/cli-clipboard-read-error.test.js && node test/cli-clipboard-write-error.test.js && node test/cli-fs-write-error.test.js && node test/single-char.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/single-char.test.js
+++ b/test/single-char.test.js
@@ -1,0 +1,21 @@
+// Verify that shrink/expand handle a single character without out-of-bounds access
+const assert = require('assert');
+const StegCloak = require('../stegcloak.js');
+const { zwcHuffMan } = require('../components/compact.js');
+
+const zwc = StegCloak.zwc;
+const { shrink, expand } = zwcHuffMan(zwc);
+
+const secret = zwc[0];
+const compressed = shrink(secret);
+const decompressed = expand(compressed);
+
+assert.strictEqual(
+  decompressed,
+  secret,
+  'Single-character strings should round-trip'
+);
+
+console.log('Single-character test passed.');
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- prevent out-of-bounds lookups in `findOptimal` by tightening while loop condition
- add unit test verifying shrink/expand handle single-character inputs
- include new test in npm test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b6517a0dac83259c8ca5d76c429dec