### PR TITLE
Validate password presence for encryption helpers

### DIFF
--- a/components/encrypt.js
+++ b/components/encrypt.js
@@ -27,6 +27,9 @@ const _genKey = (password, salt) =>
  * @returns {Buffer} Encrypted payload containing salt and optional HMAC.
  */
 const encrypt = (config) => {
+  if (typeof config.password !== "string" || config.password.length === 0) {
+    throw new Error("Password must be a non-empty string");
+  }
   // Impure function – generates random bytes for salt and IV.
   const salt = randomBytes(16);
   const { iv, key, secret } = _bootEncrypt(config, salt);
@@ -46,6 +49,9 @@ const encrypt = (config) => {
  * @returns {Buffer} Decrypted plaintext.
  */
 const decrypt = (config) => {
+  if (typeof config.password !== "string" || config.password.length === 0) {
+    throw new Error("Password must be a non-empty string");
+  }
   const { iv, key, secret, hmacData } = _bootDecrypt(config, null);
   const decipher = createDecipheriv("aes-256-ctr", key, iv);
   const decrypted = concatBuff([decipher.update(secret), decipher.final()]);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/reveal-no-payload.test.js && node test/cli-spinner.test.js && node test/hide-missing-password.test.js && node test/reveal-missing-password.test.js && node test/nocrypt-hide-reveal.test.js && node test/encrypt-salt.test.js && node test/integrity-without-crypt.test.js && node test/cli-integrity-nocrypt.test.js && node test/encrypt-binary-data.test.js && node test/cli-file-read-error.test.js && node test/cli-clipboard-read-error.test.js && node test/cli-clipboard-write-error.test.js && node test/cli-fs-write-error.test.js && node test/single-char.test.js"
+    "test": "node test/detach.test.js && node test/expand.test.js && node test/embed.test.js && node test/reveal-no-payload.test.js && node test/cli-spinner.test.js && node test/hide-missing-password.test.js && node test/reveal-missing-password.test.js && node test/nocrypt-hide-reveal.test.js && node test/encrypt-salt.test.js && node test/integrity-without-crypt.test.js && node test/cli-integrity-nocrypt.test.js && node test/encrypt-binary-data.test.js && node test/cli-file-read-error.test.js && node test/cli-clipboard-read-error.test.js && node test/cli-clipboard-write-error.test.js && node test/cli-fs-write-error.test.js && node test/single-char.test.js && node test/encrypt-invalid-password.test.js && node test/decrypt-invalid-password.test.js"
   },
   "author": "KuroLabs",
   "license": "MIT",

--- a/test/decrypt-invalid-password.test.js
+++ b/test/decrypt-invalid-password.test.js
@@ -1,0 +1,22 @@
+// Ensure decrypt throws when password is missing or empty
+const assert = require('assert');
+const { encrypt, decrypt } = require('../components/encrypt.js');
+
+const password = 'p@ssw0rd';
+const data = Buffer.from('secret');
+const payload = encrypt({ password, data, integrity: false });
+
+assert.throws(
+  () => decrypt({ password: '', data: payload, integrity: false }),
+  /non-empty string/i,
+  'decrypt should throw when password is empty'
+);
+
+assert.throws(
+  () => decrypt({ data: payload, integrity: false }),
+  /non-empty string/i,
+  'decrypt should throw when password is missing'
+);
+
+console.log('Decrypt invalid password test passed');
+process.exit(0);

--- a/test/encrypt-invalid-password.test.js
+++ b/test/encrypt-invalid-password.test.js
@@ -1,0 +1,20 @@
+// Ensure encrypt throws when password is missing or empty
+const assert = require('assert');
+const { encrypt } = require('../components/encrypt.js');
+
+const data = Buffer.from('secret');
+
+assert.throws(
+  () => encrypt({ password: '', data }),
+  /non-empty string/i,
+  'encrypt should throw when password is empty'
+);
+
+assert.throws(
+  () => encrypt({ data }),
+  /non-empty string/i,
+  'encrypt should throw when password is missing'
+);
+
+console.log('Encrypt invalid password test passed');
+process.exit(0);


### PR DESCRIPTION
## Summary
- Ensure `encrypt` and `decrypt` throw if given a missing or empty password
- Add unit tests verifying direct calls to `encrypt`/`decrypt` reject invalid passwords
- Register new tests in the npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b65519d65083259d076fce88b40f40